### PR TITLE
Replace azjezz/psl with php-standard-library/php-standard-library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php-soap/engine": "^2.16.0",
         "psr/cache": "^3.0",
         "psr/cache-implementation": "^3.0",
-        "azjezz/psl": "^3.0 || ^4.0 || ^5.0"
+        "php-standard-library/php-standard-library": "^3.0 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~12.3",


### PR DESCRIPTION
## Summary
- Replace `azjezz/psl` with `php-standard-library/php-standard-library` (drop-in replacement)
- Add `^6.0` to the version constraint

## Context
Ref: phpro/soap-client#604

## Test plan
- [x] `composer validate` passes
- [x] `composer update` resolves successfully