### PR TITLE
Bump PHP 8.4 minimum and update dependencies

### DIFF
--- a/.github/workflows/analyzers.yaml
+++ b/.github/workflows/analyzers.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['8.3', '8.4', '8.5']
+                php-versions: ['8.4', '8.5']
                 composer-options: ['--ignore-platform-req=php+']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,17 @@
         }
     ],
     "require": {
-        "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-        "php-soap/engine": "^2.16.0",
+        "php": "~8.4.0 || ~8.5.0",
+        "php-soap/engine": "^2.20.0",
         "psr/cache": "^3.0",
         "psr/cache-implementation": "^3.0",
-        "php-standard-library/php-standard-library": "^3.0 || ^4.0 || ^5.0 || ^6.0"
+        "php-standard-library/foundation": "^6.1",
+        "php-standard-library/type": "^6.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~12.3",
-        "vimeo/psalm": "~6.13.0",
-        "php-cs-fixer/shim": "~3.88.0",
+        "vimeo/psalm": "~6.16.0",
+        "php-cs-fixer/shim": "~3.94.0",
         "symfony/cache": "^7.0 || ^6.4"
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,7 +2,7 @@
 <psalm
     errorLevel="1"
     strictBinaryOperands="true"
-    phpVersion="8.1"
+    phpVersion="8.4"
     allowStringToStandInForClass="true"
     rememberPropertyAssignmentsAfterCall="false"
     skipChecksOnUnresolvableIncludes="false"


### PR DESCRIPTION
## Summary

- Drop PHP 8.3 support, require `~8.4.0 || ~8.5.0`
- Replace monolithic `php-standard-library/php-standard-library` with standalone packages (`foundation`, `type`)
- Bump `php-soap/engine` to `^2.20.0`
- Bump `psalm` to `~6.16.0`, `php-cs-fixer` to `~3.94.0`
- Update psalm `phpVersion` to `8.4`

## Validation

- php-cs-fixer: 0 issues
- psalm: no errors, 100% type inference
- phpunit: 5/5 tests pass
- Docker `docphpro/php84` (PHP 8.4.19, libxml 2.9.14): 5/5 tests pass